### PR TITLE
gateway#524: add commentsCount fields to struct

### DIFF
--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -265,6 +265,7 @@ func ParseCommitMetadata(input map[string]string) CommitMetadata {
 				WorkspaceOutputFiles: getStringSlice(prefix + "output-files"),
 				DatasetInputFiles:    getIFMap(prefix + "dataset-input-files."),
 				DatasetOutputFiles:   getStringSliceMap(prefix + "dataset-output-files."),
+				CommentsCount:        getInt64(prefix+"comments-count", 0),
 			}
 		}
 		return runs

--- a/pkg/metadata/types.go
+++ b/pkg/metadata/types.go
@@ -115,6 +115,7 @@ type RunMetadata struct {
 	Summary    map[string]string `json:"summary,omitempty"`
 	Parameters map[string]string `json:"parameters,omitempty"`
 
-	ExecStart time.Time `json:"exec_start,omitempty"`
-	ExecEnd   time.Time `json:"exec_end,omitempty"`
+	ExecStart     time.Time `json:"exec_start,omitempty"`
+	ExecEnd       time.Time `json:"exec_end,omitempty"`
+	CommentsCount int64     `json:"comments_count"`
 }


### PR DESCRIPTION
Adds a `CommentsCount` field to the `RunMetadata` type for https://github.com/dotmesh-io/gateway/pull/548